### PR TITLE
fix(rotation): cap weekly Retry-After when Claude remaining is LIVE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ antigravity-debug-*.log
 # Hive workflow internal files
 .hive/
 
+# Local git worktrees
+.worktrees/
+
 # Test artifacts
 test-file.ts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **False weekly Claude cooldown** - Antigravity 429 bodies often include weekly `RetryInfo` even when the 5-hour Claude bar is still LIVE. The plugin previously persisted that delay as `rateLimitResetTimes.claude`, so round-robin could not pick remaining accounts and fail-fast retried for hours. RPM / UNKNOWN Retry-After is now capped at 60s, `QUOTA_EXHAUSTED` Retry-After and `absoluteResetAtMs` are capped when `remainingFraction > 0`, and pick/min-wait ignore long cooldowns on accounts with fresh remaining quota.
+
 ## [1.10.0] - 2026-09-02
 
 ### Added

--- a/src/plugin/accounts.test.ts
+++ b/src/plugin/accounts.test.ts
@@ -97,6 +97,97 @@ describe("AccountManager", () => {
     expect(next).toBeNull();
   });
 
+  it("picks a Claude account whose 5h remaining is positive despite a weekly cooldown", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+
+    const stored: AccountStorageV4 = {
+      version: 4,
+      accounts: [
+        {
+          refreshToken: "exhausted",
+          projectId: "p1",
+          addedAt: 1,
+          lastUsed: 0,
+          email: "empty@example.com",
+          rateLimitResetTimes: { claude: Date.now() + 90 * 60 * 1000 },
+          cachedQuota: { claude: { remainingFraction: 0 } },
+          cachedQuotaUpdatedAt: Date.now(),
+        },
+        {
+          refreshToken: "live",
+          projectId: "p2",
+          addedAt: 1,
+          lastUsed: 0,
+          email: "live@example.com",
+          rateLimitResetTimes: { claude: Date.now() + 6.5 * 24 * 60 * 60 * 1000 },
+          cachedQuota: { claude: { remainingFraction: 1 } },
+          cachedQuotaUpdatedAt: Date.now(),
+        },
+      ],
+      activeIndex: 0,
+    };
+
+    const manager = new AccountManager(undefined, stored);
+    const account = manager.getCurrentOrNextForFamily("claude");
+    expect(account?.parts.refreshToken).toBe("live");
+    expect(manager.getMinWaitTimeForFamily("claude")).toBe(0);
+
+    vi.useRealTimers();
+  });
+
+  it("still honors a short RPM cooldown when remainingFraction is positive", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+
+    const stored: AccountStorageV4 = {
+      version: 4,
+      accounts: [
+        {
+          refreshToken: "r1",
+          projectId: "p1",
+          addedAt: 1,
+          lastUsed: 0,
+          rateLimitResetTimes: { claude: Date.now() + 30_000 },
+          cachedQuota: { claude: { remainingFraction: 1 } },
+          cachedQuotaUpdatedAt: Date.now(),
+        },
+      ],
+      activeIndex: 0,
+    };
+
+    const manager = new AccountManager(undefined, stored);
+    expect(manager.getCurrentOrNextForFamily("claude")).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it("still skips an exhausted Claude account with a long cooldown", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+
+    const stored: AccountStorageV4 = {
+      version: 4,
+      accounts: [
+        {
+          refreshToken: "r1",
+          projectId: "p1",
+          addedAt: 1,
+          lastUsed: 0,
+          rateLimitResetTimes: { claude: Date.now() + 5 * 60 * 60 * 1000 },
+          cachedQuota: { claude: { remainingFraction: 0 } },
+          cachedQuotaUpdatedAt: Date.now(),
+        },
+      ],
+      activeIndex: 0,
+    };
+
+    const manager = new AccountManager(undefined, stored);
+    expect(manager.getCurrentOrNextForFamily("claude")).toBeNull();
+
+    vi.useRealTimers();
+  });
+
   it("un-rate-limits accounts after timeout expires", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));
@@ -1241,6 +1332,23 @@ describe("AccountManager", () => {
       it("returns default backoff for UNKNOWN", () => {
         expect(calculateBackoffMs("UNKNOWN", 0)).toBe(60_000);
       });
+
+      it("caps RPM Retry-After when the server sends a weekly reset", () => {
+        const weekMs = 6.5 * 24 * 60 * 60 * 1000;
+        expect(calculateBackoffMs("RATE_LIMIT_EXCEEDED", 0, weekMs)).toBe(60_000);
+        expect(calculateBackoffMs("UNKNOWN", 0, weekMs)).toBe(60_000);
+      });
+
+      it("keeps quota Retry-After when remaining is exhausted", () => {
+        const fiveHoursMs = 5 * 60 * 60 * 1000;
+        expect(calculateBackoffMs("QUOTA_EXHAUSTED", 0, fiveHoursMs)).toBe(fiveHoursMs);
+        expect(calculateBackoffMs("QUOTA_EXHAUSTED", 0, fiveHoursMs, 0)).toBe(fiveHoursMs);
+      });
+
+      it("caps quota Retry-After when remainingFraction is still positive", () => {
+        const weekMs = 6.5 * 24 * 60 * 60 * 1000;
+        expect(calculateBackoffMs("QUOTA_EXHAUSTED", 0, weekMs, 1)).toBe(60_000);
+      });
     });
 
     describe("markRateLimitedWithReason", () => {
@@ -1299,6 +1407,77 @@ describe("AccountManager", () => {
           account, "gemini", "antigravity", null, "QUOTA_EXHAUSTED", 180_000
         );
         expect(backoff).toBe(180_000);
+
+        vi.useRealTimers();
+      });
+
+      it("does not persist a weekly Claude cooldown when cached remaining is positive", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(1_000);
+
+        const stored: AccountStorageV4 = {
+          version: 4,
+          accounts: [
+            {
+              refreshToken: "r1",
+              projectId: "p1",
+              addedAt: 1,
+              lastUsed: 0,
+              cachedQuota: { claude: { remainingFraction: 1 } },
+              cachedQuotaUpdatedAt: 1_000,
+            },
+          ],
+          activeIndex: 0,
+        };
+
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getAccounts()[0]!;
+        const weekMs = 6.5 * 24 * 60 * 60 * 1000;
+        const backoff = manager.markRateLimitedWithReason(
+          account, "claude", "antigravity", "claude-sonnet-4-6", "QUOTA_EXHAUSTED", weekMs
+        );
+
+        expect(backoff).toBe(60_000);
+        expect(account.rateLimitResetTimes.claude).toBe(1_000 + 60_000);
+
+        vi.useRealTimers();
+      });
+
+      it("caps weekly absoluteResetAtMs when cached remaining is positive", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(1_000);
+
+        const stored: AccountStorageV4 = {
+          version: 4,
+          accounts: [
+            {
+              refreshToken: "r1",
+              projectId: "p1",
+              addedAt: 1,
+              lastUsed: 0,
+              cachedQuota: { claude: { remainingFraction: 1 } },
+              cachedQuotaUpdatedAt: 1_000,
+            },
+          ],
+          activeIndex: 0,
+        };
+
+        const manager = new AccountManager(undefined, stored);
+        const account = manager.getAccounts()[0]!;
+        const weekMs = 6.5 * 24 * 60 * 60 * 1000;
+        const backoff = manager.markRateLimitedWithReason(
+          account,
+          "claude",
+          "antigravity",
+          "claude-sonnet-4-6",
+          "QUOTA_EXHAUSTED",
+          weekMs,
+          3600_000,
+          1_000 + weekMs,
+        );
+
+        expect(backoff).toBe(60_000);
+        expect(account.rateLimitResetTimes.claude).toBe(1_000 + 60_000);
 
         vi.useRealTimers();
       });

--- a/src/plugin/accounts.ts
+++ b/src/plugin/accounts.ts
@@ -34,6 +34,8 @@ const MODEL_CAPACITY_EXHAUSTED_JITTER_MAX = 30_000; // ±15s jitter range
 const SERVER_ERROR_BACKOFF = 20_000;
 const UNKNOWN_BACKOFF = 60_000;
 const MIN_BACKOFF_MS = 2_000;
+export const MAX_RPM_RETRY_AFTER_MS = 60_000;
+const DEFAULT_QUOTA_CACHE_TTL_MS = 10 * 60 * 1000;
 
 /**
  * Generate a random jitter value for backoff timing.
@@ -93,15 +95,28 @@ export function parseRateLimitReason(
   return "UNKNOWN";
 }
 
+function shouldCapRetryAfter(reason: RateLimitReason, remainingFraction?: number | null): boolean {
+  if (reason !== "QUOTA_EXHAUSTED") {
+    return true;
+  }
+  return remainingFraction != null && remainingFraction > 0;
+}
+
 export function calculateBackoffMs(
   reason: RateLimitReason,
   consecutiveFailures: number,
-  retryAfterMs?: number | null
+  retryAfterMs?: number | null,
+  remainingFraction?: number | null,
 ): number {
-  // Respect explicit Retry-After header if reasonable
+  // Respect explicit Retry-After header if reasonable, but never persist a
+  // weekly/5h reset as an RPM cooldown — Antigravity often returns weekly
+  // RetryInfo even when the 5h Claude bar is still LIVE.
   if (retryAfterMs && retryAfterMs > 0) {
-    // Rust uses 2s min buffer, we keep 2s
-    return Math.max(retryAfterMs, MIN_BACKOFF_MS);
+    const raw = Math.max(retryAfterMs, MIN_BACKOFF_MS);
+    if (shouldCapRetryAfter(reason, remainingFraction)) {
+      return Math.min(raw, MAX_RPM_RETRY_AFTER_MS);
+    }
+    return raw;
   }
   
   switch (reason) {
@@ -177,40 +192,85 @@ function getQuotaKey(family: ModelFamily, headerStyle: HeaderStyle, model?: stri
   return base;
 }
 
-function isRateLimitedForQuotaKey(account: ManagedAccount, key: QuotaKey): boolean {
-  const resetTime = account.rateLimitResetTimes[key];
-  return resetTime !== undefined && nowMs() < resetTime;
+function getFreshRemainingFraction(
+  account: ManagedAccount,
+  family: ModelFamily,
+  cacheTtlMs: number,
+  model?: string | null,
+): number | undefined {
+  if (!account.cachedQuota) return undefined;
+  if (account.cachedQuotaUpdatedAt == null) return undefined;
+  const age = nowMs() - account.cachedQuotaUpdatedAt;
+  if (age > cacheTtlMs) return undefined;
+
+  const quotaGroup = resolveQuotaGroup(family, model);
+  const fraction = account.cachedQuota[quotaGroup]?.remainingFraction;
+  if (fraction == null || !Number.isFinite(fraction)) return undefined;
+  return Math.max(0, Math.min(1, fraction));
 }
 
-function isRateLimitedForFamily(account: ManagedAccount, family: ModelFamily, model?: string | null): boolean {
+function isRateLimitedForQuotaKey(
+  account: ManagedAccount,
+  key: QuotaKey,
+  family: ModelFamily,
+  cacheTtlMs: number = DEFAULT_QUOTA_CACHE_TTL_MS,
+  model?: string | null,
+): boolean {
+  const resetTime = account.rateLimitResetTimes[key];
+  if (resetTime === undefined || nowMs() >= resetTime) {
+    return false;
+  }
+  const remainingMs = resetTime - nowMs();
+  if (remainingMs <= MAX_RPM_RETRY_AFTER_MS) {
+    return true;
+  }
+  const remaining = getFreshRemainingFraction(account, family, cacheTtlMs, model);
+  if (remaining !== undefined && remaining > 0) {
+    return false;
+  }
+  return true;
+}
+
+function isRateLimitedForFamily(
+  account: ManagedAccount,
+  family: ModelFamily,
+  model?: string | null,
+  cacheTtlMs: number = DEFAULT_QUOTA_CACHE_TTL_MS,
+): boolean {
   if (family === "claude") {
-    return isRateLimitedForQuotaKey(account, "claude");
+    return isRateLimitedForQuotaKey(account, "claude", family, cacheTtlMs, model);
   }
   
-  const antigravityIsLimited = isRateLimitedForHeaderStyle(account, family, "antigravity", model);
-  const cliIsLimited = isRateLimitedForHeaderStyle(account, family, "gemini-cli", model);
+  const antigravityIsLimited = isRateLimitedForHeaderStyle(account, family, "antigravity", model, cacheTtlMs);
+  const cliIsLimited = isRateLimitedForHeaderStyle(account, family, "gemini-cli", model, cacheTtlMs);
   
   return antigravityIsLimited && cliIsLimited;
 }
 
-function isRateLimitedForHeaderStyle(account: ManagedAccount, family: ModelFamily, headerStyle: HeaderStyle, model?: string | null): boolean {
+function isRateLimitedForHeaderStyle(
+  account: ManagedAccount,
+  family: ModelFamily,
+  headerStyle: HeaderStyle,
+  model?: string | null,
+  cacheTtlMs: number = DEFAULT_QUOTA_CACHE_TTL_MS,
+): boolean {
   clearExpiredRateLimits(account);
   
   if (family === "claude") {
-    return isRateLimitedForQuotaKey(account, "claude");
+    return isRateLimitedForQuotaKey(account, "claude", family, cacheTtlMs, model);
   }
 
   // Check model-specific quota first if provided
   if (model) {
     const modelKey = getQuotaKey(family, headerStyle, model);
-    if (isRateLimitedForQuotaKey(account, modelKey)) {
+    if (isRateLimitedForQuotaKey(account, modelKey, family, cacheTtlMs, model)) {
       return true;
     }
   }
 
   // Then check base family quota
   const baseKey = getQuotaKey(family, headerStyle);
-  return isRateLimitedForQuotaKey(account, baseKey);
+  return isRateLimitedForQuotaKey(account, baseKey, family, cacheTtlMs, model);
 }
 
 function clearExpiredRateLimits(account: ManagedAccount): void {
@@ -535,7 +595,7 @@ export class AccountManager {
             index: acc.index,
             lastUsed: acc.lastUsed,
             healthScore: healthTracker.getScore(acc.index),
-            isRateLimited: isRateLimitedForFamily(acc, family, model) || 
+            isRateLimited: isRateLimitedForFamily(acc, family, model, softQuotaCacheTtlMs) || 
                           isOverSoftQuotaThreshold(acc, family, softQuotaThresholdPercent, softQuotaCacheTtlMs, model),
             isCoolingDown: this.isAccountCoolingDown(acc),
           };
@@ -573,7 +633,7 @@ export class AccountManager {
     const current = this.getCurrentAccountForFamily(family);
     if (current) {
       clearExpiredRateLimits(current);
-      const isLimitedForRequestedStyle = isRateLimitedForHeaderStyle(current, family, headerStyle, model);
+      const isLimitedForRequestedStyle = isRateLimitedForHeaderStyle(current, family, headerStyle, model, softQuotaCacheTtlMs);
       const isOverThreshold = isOverSoftQuotaThreshold(current, family, softQuotaThresholdPercent, softQuotaCacheTtlMs, model);
       if (!isLimitedForRequestedStyle && !isOverThreshold && !this.isAccountCoolingDown(current)) {
         this.markTouchedForQuota(current, quotaKey);
@@ -593,7 +653,7 @@ export class AccountManager {
     const available = this.accounts.filter((a) => {
       clearExpiredRateLimits(a);
       return a.enabled !== false && 
-             !isRateLimitedForHeaderStyle(a, family, headerStyle, model) && 
+             !isRateLimitedForHeaderStyle(a, family, headerStyle, model, softQuotaCacheTtlMs) && 
              !isOverSoftQuotaThreshold(a, family, softQuotaThresholdPercent, softQuotaCacheTtlMs, model) &&
              !this.isAccountCoolingDown(a);
     });
@@ -655,12 +715,16 @@ export class AccountManager {
     const failures = (account.consecutiveFailures ?? 0) + 1;
     account.consecutiveFailures = failures;
     account.lastFailureTime = now;
-    
+
+    const remainingFraction = getFreshRemainingFraction(account, family, DEFAULT_QUOTA_CACHE_TTL_MS, model);
     let effectiveWaitMs: number;
     if (absoluteResetAtMs && absoluteResetAtMs > now) {
       effectiveWaitMs = absoluteResetAtMs - now;
     } else {
-      effectiveWaitMs = calculateBackoffMs(reason, failures - 1, retryAfterMs);
+      effectiveWaitMs = calculateBackoffMs(reason, failures - 1, retryAfterMs, remainingFraction);
+    }
+    if (shouldCapRetryAfter(reason, remainingFraction)) {
+      effectiveWaitMs = Math.min(Math.max(effectiveWaitMs, MIN_BACKOFF_MS), MAX_RPM_RETRY_AFTER_MS);
     }
 
     const key = getQuotaKey(family, headerStyle, model);
@@ -952,12 +1016,13 @@ export class AccountManager {
     model?: string | null,
     headerStyle?: HeaderStyle,
     strict?: boolean,
+    cacheTtlMs: number = DEFAULT_QUOTA_CACHE_TTL_MS,
   ): number {
     const available = this.accounts.filter((a) => {
       clearExpiredRateLimits(a);
       const isLimited = strict && headerStyle
-        ? isRateLimitedForHeaderStyle(a, family, headerStyle, model)
-        : isRateLimitedForFamily(a, family, model);
+        ? isRateLimitedForHeaderStyle(a, family, headerStyle, model, cacheTtlMs)
+        : isRateLimitedForFamily(a, family, model, cacheTtlMs);
       return a.enabled !== false && !isLimited && !this.isAccountCoolingDown(a);
     });
     if (available.length > 0) {


### PR DESCRIPTION
Fixes #17

Antigravity 429 bodies often include weekly `RetryInfo` / `quotaResetTime` even when the 5-hour Claude bar is still LIVE. The plugin persisted that delay as `rateLimitResetTimes.claude`, so round-robin could not pick remaining accounts and fail-fast retried for hours.

Rebased onto current `main` (v1.10.0). `absoluteResetAtMs` from server timestamps is also capped when cached remaining quota is still positive.

- Cap RPM / UNKNOWN Retry-After at 60s
- Cap `QUOTA_EXHAUSTED` Retry-After and `absoluteResetAtMs` when `remainingFraction > 0`
- Ignore long cooldowns at pick/min-wait when cached remaining quota is still positive
- Keep real 5h exhaustion (`remainingFraction === 0`) on the long cooldown